### PR TITLE
Gemfile changes from last round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@ run/
 .bundle/
 config.rb
 Gemfile.lock
+Gemfile-bricr.lock
 openstudio-measures/
 gitignore/
 output/
 bs_output/
 bs_spreadsheet_output/
+bricr_dev_files/
 reports/
 rubocop-results.xml
 spec/files/phase0/*

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 ruby '~>2.2'
 
 # Specify your gem's dependencies in bricr.gemspec
-gemspec
 
 allow_local_gems = false
 
@@ -39,25 +38,4 @@ gem 'openstudio-workflow'
 
 # simplecov has an unneccesary dependency on native json gem, use fork that does not require this
 gem 'simplecov', github: 'NREL/simplecov'
-
-# spreadsheet gem to process xls
-gem 'spreadsheet', '1.2.4'
-
-group :openstudio_no_cli do
-  #gem 'seed_ruby_client', path: '../seed_ruby-client'
-  gem 'seed_ruby_client', github: 'SEED-platform/ruby-client', branch: 'update_spec'
-  
-  gem 'unicode-display_width', '1.4.0'
-end
-
-group :test do
-  gem 'rake'
-  # gem 'coveralls', require: false # requires json gem
-  # gem 'ruby-prof', '0.15.8'
-  gem 'rspec', '~> 3.3'
-  gem 'ci_reporter_rspec'
-  gem 'rubocop', '0.54.0'
-  gem 'rubocop-checkstyle_formatter'
-  gem 'psych', '~> 3.0.3'
-end
 

--- a/Gemfile-bricr
+++ b/Gemfile-bricr
@@ -1,0 +1,29 @@
+source 'http://rubygems.org'
+ruby '~>2.2'
+
+# Specify your gem's dependencies in bricr.gemspec
+gemspec
+
+# install the OpenStudio-related gems. See other Gemfile as needed.
+eval_gemfile File.expand_path(File.join(File.dirname(__FILE__), 'Gemfile'))
+
+# spreadsheet gem to process xls
+gem 'spreadsheet', '1.2.4'
+
+group :openstudio_no_cli do
+  #gem 'seed_ruby_client', path: '../seed_ruby-client'
+  gem 'seed_ruby_client', github: 'SEED-platform/ruby-client', branch: 'update_spec'
+
+  gem 'unicode-display_width', '1.4.0'
+end
+
+group :test do
+  gem 'rake'
+  # gem 'coveralls', require: false # requires json gem
+  # gem 'ruby-prof', '0.15.8'
+  gem 'rspec', '~> 3.3'
+  gem 'ci_reporter_rspec'
+  gem 'rubocop', '0.54.0'
+  gem 'rubocop-checkstyle_formatter'
+  gem 'psych', '~> 3.0.3'
+end

--- a/bin/run_seed_buildingsyncs.rb
+++ b/bin/run_seed_buildingsyncs.rb
@@ -76,6 +76,9 @@ search_results.properties.each do |property|
   if property[analysis_state_key] == 'Not Started'
     properties << property
   end
+  if properties.size >= BRICR::PROPERTY_COUNT
+    break
+  end
 end
 
 properties = properties.select{|property| property[analysis_state_key] == 'Not Started'} # DLM: temp work around 

--- a/config.rb.in
+++ b/config.rb.in
@@ -4,6 +4,9 @@ module BRICR
   MAX_DATAPOINTS = Float::INFINITY
   #MAX_DATAPOINTS = 2
 
+  # used in run_seed_buildingsyncs to limit the number of properties to keep after each pull from SEED
+  PROPERTY_COUNT = 2
+
   # number of parallel jobs per BuildingSync file
   NUM_PARALLEL = 4
 


### PR DESCRIPTION
* Break up Gemfiles between what is needed for BRICR and what is needed to run openstudio simulations
* Add the PROPERTY_COUNT variable to the config.rb to limit the number of SEED properties to simulate at a time.